### PR TITLE
Add configurable HTTP client to Loginradius struct

### DIFF
--- a/api/account/delete.go
+++ b/api/account/delete.go
@@ -14,7 +14,7 @@ func (lr Loginradius) DeleteManageAccount(uid string) (*httprutils.Response, err
 	lr.Client.AddApiCredentialsToReqHeader(request)
 	request.URL = request.URL + uid
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -39,6 +39,6 @@ func (lr Loginradius) DeleteManageAccountEmail(uid string, body interface{}) (*h
 		Body: encoded,
 	}
 	lr.Client.AddApiCredentialsToReqHeader(&request)
-	response, err := httprutils.TimeoutClient.Send(request)
+	response, err := lr.Client.HTTPRClient.Send(request)
 	return response, err
 }

--- a/api/account/get.go
+++ b/api/account/get.go
@@ -20,7 +20,7 @@ func (lr Loginradius) GetManageAccountProfilesByEmail(queries interface{}) (*htt
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -39,7 +39,7 @@ func (lr Loginradius) GetManageAccountProfilesByUsername(queries interface{}) (*
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -58,7 +58,7 @@ func (lr Loginradius) GetManageAccountProfilesByPhoneID(queries interface{}) (*h
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -72,7 +72,7 @@ func (lr Loginradius) GetManageAccountProfilesByPhoneID(queries interface{}) (*h
 func (lr Loginradius) GetManageAccountProfilesByUid(uid string) (*httprutils.Response, error) {
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/" + uid)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -97,7 +97,7 @@ func (lr Loginradius) GetManageAccountIdentitiesByEmail(queries interface{}) (*h
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/identities", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -114,7 +114,7 @@ func (lr Loginradius) GetManageAccessTokenUID(queries interface{}) (*httprutils.
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/access_token", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -126,7 +126,7 @@ func (lr Loginradius) GetManageAccessTokenUID(queries interface{}) (*httprutils.
 func (lr Loginradius) GetManageAccountPassword(uid string) (*httprutils.Response, error) {
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/" + uid + "/password")
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -144,7 +144,7 @@ func (lr Loginradius) GetRefreshAccessTokenByRefreshToken(queries interface{}) (
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/access_token/refresh", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -162,7 +162,7 @@ func (lr Loginradius) GetRevokeRefreshToken(queries interface{}) (*httprutils.Re
 	}
 	request := lr.Client.NewGetReq("/identity/v2/manage/account/access_token/refresh/revoke", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 

--- a/api/account/post.go
+++ b/api/account/post.go
@@ -26,7 +26,7 @@ func (lr Loginradius) PostManageAccountCreate(body interface{}) (*httprutils.Res
 
 	lr.Client.AddApiCredentialsToReqHeader(request)
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -63,7 +63,7 @@ func (lr Loginradius) PostManageForgotPasswordToken(body interface{}, queries ..
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -81,6 +81,6 @@ func (lr Loginradius) PostManageEmailVerificationToken(body interface{}) (*httpr
 		return nil, err
 	}
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/account/put.go
+++ b/api/account/put.go
@@ -25,7 +25,7 @@ func (lr Loginradius) PutManageAccountUpdateSecurityQuestionConfig(uid string, b
 	}
 	lr.Client.AddApiCredentialsToReqHeader(request)
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -47,7 +47,7 @@ func (lr Loginradius) PutManageAccountSetPassword(uid string, body interface{}) 
 	}
 	lr.Client.AddApiCredentialsToReqHeader(request)
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -69,7 +69,7 @@ func (lr Loginradius) PutManageAccountUpdate(uid string, body interface{}) (*htt
 	}
 	lr.Client.AddApiCredentialsToReqHeader(request)
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -99,6 +99,6 @@ func (lr Loginradius) PutManageAccountInvalidateVerificationEmail(uid string, qu
 	}
 
 	lr.Client.AddApiCredentialsToReqHeader(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/authentication/delete.go
+++ b/api/authentication/delete.go
@@ -31,7 +31,7 @@ func (lr Loginradius) DeleteAuthDeleteAccountEmailConfirmation(queries ...interf
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -49,7 +49,7 @@ func (lr Loginradius) DeleteAuthRemoveEmail(body interface{}) (*httprutils.Respo
 	if err != nil {
 		return nil, err
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -68,6 +68,6 @@ func (lr Loginradius) DeleteAuthUnlinkSocialIdentities(body interface{}) (*httpr
 	if err != nil {
 		return nil, err
 	}
-	response, err := httprutils.TimeoutClient.Send(*req)
+	response, err := lr.Client.HTTPRClient.Send(*req)
 	return response, err
 }

--- a/api/authentication/get.go
+++ b/api/authentication/get.go
@@ -24,7 +24,7 @@ func (lr Loginradius) GetAuthVerifyEmail(queries interface{}) (*httprutils.Respo
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 
 	req := lr.Client.NewGetReq("/identity/v2/auth/email", validatedQueries)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -42,7 +42,7 @@ func (lr Loginradius) GetAuthCheckEmailAvailability(queries interface{}) (*httpr
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 
 	req := lr.Client.NewGetReq("/identity/v2/auth/email", validatedQueries)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -61,7 +61,7 @@ func (lr Loginradius) GetAuthCheckUsernameAvailability(queries interface{}) (*ht
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 
 	req := lr.Client.NewGetReq("/identity/v2/auth/username", validatedQueries)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -75,7 +75,7 @@ func (lr Loginradius) GetAuthReadProfilesByToken() (*httprutils.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -87,7 +87,7 @@ func (lr Loginradius) GetAuthPrivatePolicyAccept() (*httprutils.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -112,7 +112,7 @@ func (lr Loginradius) GetAuthSendWelcomeEmail(queries ...interface{}) (*httpruti
 		}
 	}
 
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -127,7 +127,7 @@ func (lr Loginradius) GetAuthSocialIdentity() (*httprutils.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -142,7 +142,7 @@ func (lr Loginradius) GetAuthValidateAccessToken() (*httprutils.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -159,7 +159,7 @@ func (lr Loginradius) GetAuthDeleteAccount(queries interface{}) (*httprutils.Res
 	}
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 	req := lr.Client.NewGetReq("/identity/v2/auth/account/delete", validatedQueries)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -173,7 +173,7 @@ func (lr Loginradius) GetAuthInvalidateAccessToken() (*httprutils.Response, erro
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -189,7 +189,7 @@ func (lr Loginradius) GetAuthSecurityQuestionByAccessToken() (*httprutils.Respon
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -211,7 +211,7 @@ func (lr Loginradius) GetAuthSecurityQuestionByEmail(queries interface{}) (*http
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -233,7 +233,7 @@ func (lr Loginradius) GetAuthSecurityQuestionByUsername(queries interface{}) (*h
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -255,7 +255,7 @@ func (lr Loginradius) GetAuthSecurityQuestionByPhone(queries interface{}) (*http
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -276,7 +276,7 @@ func (lr Loginradius) GetPasswordlessLoginByEmail(queries interface{}) (*httprut
 
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/passwordlesslogin/email", validatedQueries)
 
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -296,7 +296,7 @@ func (lr Loginradius) GetPasswordlessLoginByUsername(queries interface{}) (*http
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/passwordlesslogin/email", validatedQueries)
 
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -316,6 +316,6 @@ func (lr Loginradius) GetPasswordlessLoginVerification(queries interface{}) (*ht
 	validatedQueries["apiKey"] = lr.Client.Context.ApiKey
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/passwordlesslogin/email/verify", validatedQueries)
 
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/authentication/post.go
+++ b/api/authentication/post.go
@@ -34,7 +34,7 @@ func (lr Loginradius) PostAuthAddEmail(body interface{}, queries ...interface{})
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -61,7 +61,7 @@ func (lr Loginradius) PostAuthForgotPassword(body interface{}, queries interface
 	if err != nil {
 		return nil, err
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -92,7 +92,7 @@ func (lr Loginradius) PostAuthUserRegistrationByEmail(sott string,body interface
 	request, err := lr.Client.NewPostReq("/identity/v2/auth/register", body, queryParams)
 
 	request.Headers["X-LoginRadius-Sott"] = sott
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -121,7 +121,7 @@ func (lr Loginradius) PostAuthLoginByEmail(body interface{}, queries ...interfac
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -148,6 +148,6 @@ func (lr Loginradius) PostAuthLoginByUsername(body interface{}, queries ...inter
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/authentication/put.go
+++ b/api/authentication/put.go
@@ -34,7 +34,7 @@ func (lr Loginradius) PutAuthVerifyEmailByOtp(body interface{}, queries ...inter
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -56,7 +56,7 @@ func (lr Loginradius) PutAuthChangePassword(body interface{}) (*httprutils.Respo
 		return nil, err
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -74,7 +74,7 @@ func (lr Loginradius) PutAuthLinkSocialIdentities(token string, body interface{}
 		return nil, err
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -108,7 +108,7 @@ func (lr Loginradius) PutResendEmailVerification(body interface{}, queries ...in
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -130,7 +130,7 @@ func (lr Loginradius) PutAuthResetPasswordByResetToken(body interface{}) (*httpr
 		return nil, err
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -167,7 +167,7 @@ func (lr Loginradius) PutAuthResetPasswordByOTP(body interface{}, queries ...int
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -187,7 +187,7 @@ func (lr Loginradius) PutAuthResetPasswordByOTP(body interface{}, queries ...int
 // []byte could also be passed as body
 func (lr Loginradius) PutAuthResetPasswordBySecurityAnswerAndEmail(body interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/password/securityanswer", body)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -207,7 +207,7 @@ func (lr Loginradius) PutAuthResetPasswordBySecurityAnswerAndEmail(body interfac
 // []byte could also be passed as body
 func (lr Loginradius) PutAuthResetPasswordBySecurityAnswerAndPhone(body interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/password/securityanswer", body)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -227,7 +227,7 @@ func (lr Loginradius) PutAuthResetPasswordBySecurityAnswerAndPhone(body interfac
 // []byte could also be passed as body
 func (lr Loginradius) PutAuthResetPasswordBySecurityAnswerAndUsername(body interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/password/securityanswer", body)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -245,7 +245,7 @@ func (lr Loginradius) PutAuthSetOrChangeUsername(body interface{}) (*httprutils.
 	if err != nil {
 		return nil, err
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -279,7 +279,7 @@ func (lr Loginradius) PutAuthUpdateProfileByToken(body interface{}, queries ...i
 		}
 	}
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -298,6 +298,6 @@ func (lr Loginradius) PutAuthUpdateSecurityQuestionByAccessToken(body interface{
 	if err != nil {
 		return nil, err
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/configuration/configuration.go
+++ b/api/configuration/configuration.go
@@ -13,7 +13,7 @@ func (lr Loginradius) GetConfiguration() (*httprutils.Response, error) {
 	req := lr.Client.NewGetReq("")
 	req.URL = "https://config.lrcontent.com/ciam/appinfo"
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -36,7 +36,7 @@ func (lr Loginradius) GetServerTime(queries ...interface{}) (*httprutils.Respons
 		}
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -57,7 +57,7 @@ func (lr Loginradius) GetGenerateSottAPI(queries ...interface{}) (*httprutils.Re
 		}
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -75,7 +75,7 @@ func (lr Loginradius) GetActiveSessionDetails() (*httprutils.Response, error) {
 	)
 	req.URL = "http://api.loginradius.com/api/v2/access_token/activesession"
 	delete(req.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 	// data := new(ActiveSession)
 	// req, reqErr := CreateRequest("GET", "http://api.loginradius.com/api/v2/access_token/activesession", "")

--- a/api/customobject/customobject.go
+++ b/api/customobject/customobject.go
@@ -32,7 +32,7 @@ func (lr Loginradius) PostCustomObjectCreateByUID(uid string, queries interface{
 	}
 
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -57,7 +57,7 @@ func (lr Loginradius) PostCustomObjectCreateByToken(queries interface{}, body in
 		return nil, err
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -79,7 +79,7 @@ func (lr Loginradius) GetCustomObjectByObjectRecordIDAndUID(uid, objectRecordID 
 
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/"+uid+"/customobject/"+objectRecordID, validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -103,7 +103,7 @@ func (lr Loginradius) GetCustomObjectByObjectRecordIDAndToken(objectRecordID str
 	if err != nil {
 		return nil, err
 	}
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -124,7 +124,7 @@ func (lr Loginradius) GetCustomObjectByToken(queries interface{}) (*httprutils.R
 		return nil, err
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -144,7 +144,7 @@ func (lr Loginradius) GetCustomObjectByUID(uid string, queries interface{}) (*ht
 
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/"+uid+"/customobject/", validatedQueries)
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -172,7 +172,7 @@ func (lr Loginradius) PutCustomObjectUpdateByUID(uid, objectrecordid string, que
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -199,7 +199,7 @@ func (lr Loginradius) PutCustomObjectUpdateByToken(objectrecordid string, querie
 		return nil, err
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -222,7 +222,7 @@ func (lr Loginradius) DeleteCustomObjectByObjectRecordIDAndUID(uid, objectRecord
 	req.QueryParams = validatedQueries
 	lr.Client.AddApiCredentialsToReqHeader(req)
 	req.Headers["content-Type"] = "application/json"
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -250,6 +250,6 @@ func (lr Loginradius) DeleteCustomObjectByObjectRecordIDAndToken(objectRecordId 
 	req.QueryParams = validatedQueries
 	req.Headers["content-Type"] = "application/json"
 	lr.Client.NormalizeApiKey(req)
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }

--- a/api/mfa/delete.go
+++ b/api/mfa/delete.go
@@ -22,7 +22,7 @@ func (lr Loginradius) DeleteMFAResetGoogleAuthenticatorByToken() (*httprutils.Re
 	}
 	lr.Client.NormalizeApiKey(req)
 	req.Headers["content-Type"] = "application/json"
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -43,7 +43,7 @@ func (lr Loginradius) DeleteMFAResetSMSAuthenticatorByToken() (*httprutils.Respo
 	}
 	lr.Client.NormalizeApiKey(req)
 	req.Headers["content-Type"] = "application/json"
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -76,7 +76,7 @@ func (lr Loginradius) DeleteMFAResetSMSAuthenticatorByUid(queries interface{}) (
 	)
 	req.QueryParams = queryParams
 	req.Headers = httprutils.JSONHeader
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -109,6 +109,6 @@ func (lr Loginradius) DeleteMFAResetGoogleAuthenticatorByUid(queries interface{}
 	)
 	req.Headers = httprutils.JSONHeader
 	req.QueryParams = queryParams
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/mfa/get.go
+++ b/api/mfa/get.go
@@ -34,7 +34,7 @@ func (lr Loginradius) GetMFAValidateAccessToken(queries ...interface{}) (*httpru
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -49,7 +49,7 @@ func (lr Loginradius) GetMFABackUpCodeByAccessToken() (*httprutils.Response, err
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -64,7 +64,7 @@ func (lr Loginradius) GetMFAResetBackUpCodeByAccessToken() (*httprutils.Response
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -93,7 +93,7 @@ func (lr Loginradius) GetMFABackUpCodeByUID(queries interface{}) (*httprutils.Re
 
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/2fa/backupcode", queryParams)
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -119,7 +119,7 @@ func (lr Loginradius) GetMFAResetBackUpCodeByUID(queries interface{}) (*httpruti
 
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/2fa/backupcode/reset", queryParams)
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -144,6 +144,6 @@ func (lr Loginradius) GetMFAReAuthenticate(queries ...interface{}) (*httprutils.
 		}
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/mfa/post.go
+++ b/api/mfa/post.go
@@ -29,7 +29,7 @@ func (lr Loginradius) PostMFAEmailLogin(body interface{}, queries ...interface{}
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -57,7 +57,7 @@ func (lr Loginradius) PostMFAUsernameLogin(body interface{}, queries ...interfac
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -85,6 +85,6 @@ func (lr Loginradius) PostMFAPhoneLogin(body interface{}, queries ...interface{}
 			request.QueryParams[k] = v
 		}
 	}
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/mfa/put.go
+++ b/api/mfa/put.go
@@ -30,7 +30,7 @@ func (lr Loginradius) PutMFAValidateGoogleAuthCode(queries, body interface{}) (*
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -59,7 +59,7 @@ func (lr Loginradius) PutMFAValidateOTP(queries, body interface{}) (*httprutils.
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -92,7 +92,7 @@ func (lr Loginradius) PutMFAUpdateByToken(body interface{}, queries ...interface
 		}
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -119,7 +119,7 @@ func (lr Loginradius) PutMFAUpdatePhoneNumber(queries, body interface{}) (*httpr
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -153,7 +153,7 @@ func (lr Loginradius) PutMFAUpdatePhoneNumberByToken(body interface{}, queries .
 	}
 
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -178,7 +178,7 @@ func (lr Loginradius) PutMFAValidateBackupCode(queries interface{}, body interfa
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -195,7 +195,7 @@ func (lr Loginradius) PutMFAReauthenticateByGoogleAuthenticator(body interface{}
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -209,7 +209,7 @@ func (lr Loginradius) PutMFAReauthenticateByBackupCode(body interface{}) (*httpr
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -228,7 +228,7 @@ func (lr Loginradius) PutMFAReauthenticateByOTP(body interface{}) (*httprutils.R
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -247,7 +247,7 @@ func (lr Loginradius) PutMFAReauthenticateByPassword(body interface{}) (*httprut
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -266,6 +266,6 @@ func (lr Loginradius) PutMFAUpdateSettings(body interface{}) (*httprutils.Respon
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/onetouchlogin/onetouchlogin.go
+++ b/api/onetouchlogin/onetouchlogin.go
@@ -32,7 +32,7 @@ func (lr Loginradius) PostOneTouchLoginByEmail(body interface{}, queries ...inte
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -62,7 +62,7 @@ func (lr Loginradius) PostOneTouchLoginByPhone(body interface{}, queries ...inte
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -84,6 +84,6 @@ func (lr Loginradius) PutOneTouchOTPVerification(queries, body interface{}) (*ht
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/phoneauthentication/phoneauthentication.go
+++ b/api/phoneauthentication/phoneauthentication.go
@@ -34,7 +34,7 @@ func (lr Loginradius) PostPhoneLogin(body interface{}, queries ...interface{}) (
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -64,7 +64,7 @@ func (lr Loginradius) PostPhoneForgotPasswordByOTP(body interface{}, queries ...
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -96,7 +96,7 @@ func (lr Loginradius) PostPhoneResendVerificationOTP(body interface{}, queries .
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -128,7 +128,7 @@ func (lr Loginradius) PostPhoneResendVerificationOTPByToken(body interface{}, qu
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -164,7 +164,7 @@ func (lr Loginradius) PostPhoneUserRegistrationBySMS(sott string,body interface{
 	request, err := lr.Client.NewPostReq("/identity/v2/auth/register", body, queryParams)
 
 	request.Headers["X-LoginRadius-Sott"] = sott
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -186,7 +186,7 @@ func (lr Loginradius) GetPhoneSendOTP(queries interface{}) (*httprutils.Response
 	validatedQueries["apikey"] = lr.Client.Context.ApiKey
 	request := lr.Client.NewGetReq("/identity/v2/auth/login/passwordlesslogin/otp", validatedQueries)
 	delete(request.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*request)
+	res, err := lr.Client.HTTPRClient.Send(*request)
 	return res, err
 }
 
@@ -203,7 +203,7 @@ func (lr Loginradius) GetPhoneNumberAvailability(queries interface{}) (*httpruti
 	}
 	req := lr.Client.NewGetReq("/identity/v2/auth/phone", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -232,7 +232,7 @@ func (lr Loginradius) PutPhoneLoginUsingOTP(body interface{}, queries ...interfa
 		}
 	}
 	lr.Client.NormalizeApiKey(request)
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -263,7 +263,7 @@ func (lr Loginradius) PutPhoneNumberUpdate(body interface{}, queries ...interfac
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -281,7 +281,7 @@ func (lr Loginradius) PutPhoneResetPasswordByOTP(body interface{}) (*httprutils.
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -307,7 +307,7 @@ func (lr Loginradius) PutPhoneVerificationByOTP(queries, body interface{}) (*htt
 		return nil, err
 	}
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -336,7 +336,7 @@ func (lr Loginradius) PutPhoneVerificationByOTPByToken(queries interface{}) (*ht
 	}
 	lr.Client.NormalizeApiKey(req)
 
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -355,7 +355,7 @@ func (lr Loginradius) PutResetPhoneIDVerification(uid string) (*httprutils.Respo
 		"apisecret": lr.Client.Context.ApiSecret,
 	}
 	req.Headers = httprutils.URLEncodedHeader
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -369,6 +369,6 @@ func (lr Loginradius) DeleteRemovePhoneIDByAccessToken() (*httprutils.Response, 
 	if err != nil {
 		return nil, err
 	}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/role/role.go
+++ b/api/role/role.go
@@ -22,7 +22,7 @@ func (lr Loginradius) PostRolesCreate(body interface{}) (*httprutils.Response, e
 		return nil, err
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -34,7 +34,7 @@ func (lr Loginradius) PostRolesCreate(body interface{}) (*httprutils.Response, e
 func (lr Loginradius) DeleteAccountRole(role string) (*httprutils.Response, error) {
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/role/" + role)
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -46,7 +46,7 @@ func (lr Loginradius) DeleteAccountRole(role string) (*httprutils.Response, erro
 func (lr Loginradius) GetContextRolesPermissions(uid string) (*httprutils.Response, error) {
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/" + uid + "/rolecontext")
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -56,7 +56,7 @@ func (lr Loginradius) GetContextRolesPermissions(uid string) (*httprutils.Respon
 func (lr Loginradius) GetRolesList() (*httprutils.Response, error) {
 	req := lr.Client.NewGetReq("/identity/v2/manage/role")
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -68,7 +68,7 @@ func (lr Loginradius) GetRolesList() (*httprutils.Response, error) {
 func (lr Loginradius) GetRolesByUID(uid string) (*httprutils.Response, error) {
 	req := lr.Client.NewGetReq("/identity/v2/manage/account/" + uid + "/role")
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -88,7 +88,7 @@ func (lr Loginradius) PutAccountAddPermissionsToRole(role string, body interface
 		return nil, err
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -108,7 +108,7 @@ func (lr Loginradius) PutRolesAssignToUser(uid string, body interface{}) (*httpr
 		return nil, err
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -129,7 +129,7 @@ func (lr Loginradius) PutRolesUpsertContext(uid string, body interface{}) (*http
 	}
 	lr.Client.AddApiCredentialsToReqHeader(req)
 	fmt.Println(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -146,7 +146,7 @@ func (lr Loginradius) DeleteRolesAssignedToUser(uid string, body interface{}) (*
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/account/"+uid+"/role", body)
 	req.Headers = httprutils.JSONHeader
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -164,7 +164,7 @@ func (lr Loginradius) DeleteRolesAccountRemovePermissions(roleName string, body 
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/role/"+roleName+"/permission", body)
 	req.Headers = httprutils.JSONHeader
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -178,7 +178,7 @@ func (lr Loginradius) DeleteContextFromRole(uid, rolecontextname string) (*httpr
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/account/" + uid + "/rolecontext/" + rolecontextname)
 	req.Headers = httprutils.JSONHeader
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -194,7 +194,7 @@ func (lr Loginradius) DeleteRoleFromContext(uid, rolecontextname string, body in
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/account/"+uid+"/rolecontext/"+rolecontextname+"/role", body)
 	req.Headers = httprutils.JSONHeader
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -210,6 +210,6 @@ func (lr Loginradius) DeleteAdditionalPermissionFromContext(uid, rolecontextname
 	req := lr.Client.NewDeleteReq("/identity/v2/manage/account/"+uid+"/rolecontext/"+rolecontextname+"/additionalpermission", body)
 	req.Headers = httprutils.JSONHeader
 	lr.Client.AddApiCredentialsToReqHeader(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/smartlogin/smartlogin.go
+++ b/api/smartlogin/smartlogin.go
@@ -20,7 +20,7 @@ func (lr Loginradius) GetSmartLoginByEmail(queries interface{}) (*httprutils.Res
 	}
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/smartlogin", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -38,7 +38,7 @@ func (lr Loginradius) GetSmartLoginByUsername(queries interface{}) (*httprutils.
 	}
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/smartlogin", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -53,7 +53,7 @@ func (lr Loginradius) GetSmartLoginPing(queries interface{}) (*httprutils.Respon
 	}
 	req := lr.Client.NewGetReq("/identity/v2/auth/login/smartlogin/ping", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -71,6 +71,6 @@ func (lr Loginradius) GetSmartLoginVerifyToken(queries interface{}) (*httprutils
 	}
 	req := lr.Client.NewGetReq("/identity/v2/auth/email/smartlogin", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/api/social/get.go
+++ b/api/social/get.go
@@ -22,7 +22,7 @@ func (lr Loginradius) GetSocialAccessToken(requestToken string) (*httprutils.Res
 		"secret": lr.Client.Context.ApiSecret,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -43,7 +43,7 @@ func (lr Loginradius) GetSocialTokenValidate() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -79,7 +79,7 @@ func (lr Loginradius) GetSocialTokenInvalidate(queries ...interface{}) (*httprut
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -104,7 +104,7 @@ func (lr Loginradius) GetSocialAlbum() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -129,7 +129,7 @@ func (lr Loginradius) GetSocialAudio() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -154,7 +154,7 @@ func (lr Loginradius) GetSocialCheckin() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -177,7 +177,7 @@ func (lr Loginradius) GetSocialCompany() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -205,7 +205,7 @@ func (lr Loginradius) GetSocialContact() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -226,7 +226,7 @@ func (lr Loginradius) GetSocialEvent() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -250,7 +250,7 @@ func (lr Loginradius) GetSocialFollowing() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -274,7 +274,7 @@ func (lr Loginradius) GetSocialGroup() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -297,7 +297,7 @@ func (lr Loginradius) GetSocialLike() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -320,7 +320,7 @@ func (lr Loginradius) GetSocialMention() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -353,7 +353,7 @@ func (lr Loginradius) GetSocialStatusPost(queries interface{}) (*httprutils.Resp
 
 	request := lr.Client.NewGetReq("/api/v2/status/js", validatedQueries)
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -378,7 +378,7 @@ func (lr Loginradius) GetSocialPage(pagename string) (*httprutils.Response, erro
 		"access_token": lr.Client.Context.Token, "pagename": pagename,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -402,7 +402,7 @@ func (lr Loginradius) GetSocialPhoto(albumid string) (*httprutils.Response, erro
 		"access_token": lr.Client.Context.Token, "albumid": albumid,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -426,7 +426,7 @@ func (lr Loginradius) GetSocialPost() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -450,7 +450,7 @@ func (lr Loginradius) GetSocialStatus() (*httprutils.Response, error) {
 		"access_token": lr.Client.Context.Token,
 	})
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }
 
@@ -486,6 +486,6 @@ func (lr Loginradius) GetSocialVideo(queries ...interface{}) (*httprutils.Respon
 		}
 	}
 
-	resp, err := httprutils.TimeoutClient.Send(*req)
+	resp, err := lr.Client.HTTPRClient.Send(*req)
 	return resp, err
 }

--- a/api/social/post.go
+++ b/api/social/post.go
@@ -42,7 +42,7 @@ func (lr Loginradius) PostSocialMessageAPI(queries interface{}) (*httprutils.Res
 
 	request.Headers = httprutils.URLEncodedHeader
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
 
@@ -77,6 +77,6 @@ func (lr Loginradius) PostSocialStatusPost(queries interface{}) (*httprutils.Res
 
 	request.Headers = httprutils.URLEncodedHeader
 
-	response, err := httprutils.TimeoutClient.Send(*request)
+	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }

--- a/api/tokenmanagement/tokenmanagement.go
+++ b/api/tokenmanagement/tokenmanagement.go
@@ -22,7 +22,7 @@ func (lr Loginradius) GetAccessTokenViaFacebook(queries interface{}) (*httprutil
 	req := lr.Client.NewGetReq("/api/v2/access_token/facebook", validatedQueries)
 
 	delete(req.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -40,7 +40,7 @@ func (lr Loginradius) GetAccessTokenViaTwitter(queries interface{}) (*httprutils
 	req := lr.Client.NewGetReq("/api/v2/access_token/twitter", validatedQueries)
 
 	delete(req.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -58,7 +58,7 @@ func (lr Loginradius) GetAccessTokenViaVkontakte(queries interface{}) (*httpruti
 	req := lr.Client.NewGetReq("/api/v2/access_token/vkontakte", validatedQueries)
 
 	delete(req.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -78,7 +78,7 @@ func (lr Loginradius) GetRefreshUserProfile() (*httprutils.Response, error) {
 
 	req := lr.Client.NewGetReq("/api/v2/userprofile/refresh")
 	req.QueryParams = map[string]string{"access_token": lr.Client.Context.Token}
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -115,7 +115,7 @@ func (lr Loginradius) GetRefreshToken(queries ...interface{}) (*httprutils.Respo
 
 	req := lr.Client.NewGetReq("/api/v2/access_token/refresh", queryParams)
 	delete(req.QueryParams, "apiKey")
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 

--- a/api/webhook/webhook.go
+++ b/api/webhook/webhook.go
@@ -19,7 +19,7 @@ func (lr Loginradius) PostWebhookSubscribe(body interface{}) (*httprutils.Respon
 	}
 	lr.Client.NormalizeApiKey(req)
 	req.QueryParams["apisecret"] = lr.Client.Context.ApiSecret
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -30,7 +30,7 @@ func (lr Loginradius) GetWebhookTest() (*httprutils.Response, error) {
 	req := lr.Client.NewGetReq("/api/v2/webhook/test")
 	lr.Client.NormalizeApiKey(req)
 	req.QueryParams["apisecret"] = lr.Client.Context.ApiSecret
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -47,7 +47,7 @@ func (lr Loginradius) GetWebhookSubscribedURLs(queries interface{}) (*httprutils
 	validatedQueries["apisecret"] = lr.Client.Context.ApiSecret
 	req := lr.Client.NewGetReq("/api/v2/webhook", validatedQueries)
 	lr.Client.NormalizeApiKey(req)
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }
 
@@ -63,6 +63,6 @@ func (lr Loginradius) DeleteWebhookUnsubscribe(body interface{}) (*httprutils.Re
 		"apikey":    lr.Client.Context.ApiKey,
 	}
 	req.Headers = httprutils.JSONHeader
-	res, err := httprutils.TimeoutClient.Send(*req)
+	res, err := lr.Client.HTTPRClient.Send(*req)
 	return res, err
 }

--- a/loginradius.go
+++ b/loginradius.go
@@ -4,6 +4,7 @@ package loginradius
 import (
 	"errors"
 
+	"github.com/LoginRadius/go-sdk/httprutils"
 	"github.com/LoginRadius/go-sdk/lrerror"
 )
 
@@ -13,8 +14,9 @@ const domain = "https://api.loginradius.com"
 // Loginradius struct holds context for intializing the Loginradius client and the domain for API calls
 // Domain can be changed after intialization
 type Loginradius struct {
-	Context *Context
-	Domain  string
+	Context     *Context
+	Domain      string
+	HTTPRClient *httprutils.Client
 }
 
 // Config struct contains Loginradius credentials and is used when initalizing the Loginradius API client struct
@@ -65,7 +67,8 @@ func NewLoginradius(cfg *Config, optionalArgs ...map[string]string) (*Loginradiu
 	}
 
 	return &Loginradius{
-		Context: &ctx,
-		Domain:  domain,
+		Context:     &ctx,
+		Domain:      domain,
+		HTTPRClient: httprutils.TimeoutClient,
 	}, nil
 }


### PR DESCRIPTION
## Summary
  - Added `HTTPRClient *httprutils.Client` field to the `Loginradius` struct, enabling consumers to inject a custom HTTP client
  - Replaced all 157 occurrences of `httprutils.TimeoutClient.Send(...)` with `lr.Client.HTTPRClient.Send(...)` across 22 API files
  - Backward compatible: `NewLoginradius()` defaults `HTTPRClient` to `httprutils.TimeoutClient`

  ## Usage
  ```go
  lrclient, _ := lr.NewLoginradius(&cfg)
  // Optionally inject a custom HTTP client:
  lrclient.HTTPRClient = &httprutils.Client{HTTPClient: customHTTPClient}