### PR TITLE
feat(httprutils): propagate context through outbound HTTP requests

### DIFF
--- a/api/authentication/post.go
+++ b/api/authentication/post.go
@@ -1,6 +1,8 @@
 package lrauthentication
 
 import (
+	"context"
+
 	"github.com/LoginRadius/go-sdk/httprutils"
 	lrvalidate "github.com/LoginRadius/go-sdk/internal/validate"
 )
@@ -49,7 +51,7 @@ func (lr Loginradius) PostAuthAddEmail(body interface{}, queries ...interface{})
 // Required post parameter - email: string
 
 // Pass data in struct lrbody.EmailStr as body to help ensure parameters satisfy API requirements
-func (lr Loginradius) PostAuthForgotPassword(body interface{}, queries interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PostAuthForgotPassword(ctx context.Context, body interface{}, queries interface{}) (*httprutils.Response, error) {
 	allowedQueries := map[string]bool{"resetpasswordurl": true, "emailtemplate": true}
 	validatedQueries, err := lrvalidate.Validate(allowedQueries, queries)
 
@@ -61,6 +63,7 @@ func (lr Loginradius) PostAuthForgotPassword(body interface{}, queries interface
 	if err != nil {
 		return nil, err
 	}
+	request.WithContext(ctx)
 	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
 }
@@ -108,8 +111,12 @@ func (lr Loginradius) PostAuthUserRegistrationByEmail(sott string, body interfac
 // Required query parameters: apiKey; optional query parameters: verificationurl, loginurl, emailtemplate, g-recaptcha-response
 
 // Required body parameters: email, password; optional body parameters: security answer
-func (lr Loginradius) PostAuthLoginByEmail(body interface{}, queries ...interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PostAuthLoginByEmail(ctx context.Context, body interface{}, queries ...interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPostReq("/identity/v2/auth/login", body)
+	if err != nil {
+		return nil, err
+	}
+	request.WithContext(ctx)
 	for _, arg := range queries {
 		allowedQueries := map[string]bool{
 			"verificationurl": true, "loginurl": true, "emailtemplate": true, "g-recaptcha-response": true,

--- a/api/authentication/put.go
+++ b/api/authentication/put.go
@@ -1,6 +1,8 @@
 package lrauthentication
 
 import (
+	"context"
+
 	"github.com/LoginRadius/go-sdk/httprutils"
 	lrvalidate "github.com/LoginRadius/go-sdk/internal/validate"
 )
@@ -14,11 +16,12 @@ import (
 // Optional post parameters - qq_captcha_randstr: string;g-recaptcha-response:string; securityanswer; string; qq_captcha_ticket: string;
 
 // Required query parameter: apiKey; Optional query parameters: url, welcometemplate
-func (lr Loginradius) PutAuthVerifyEmailByOtp(body interface{}, queries ...interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PutAuthVerifyEmailByOtp(ctx context.Context, body interface{}, queries ...interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/email", body)
 	if err != nil {
 		return nil, err
 	}
+	request.WithContext(ctx)
 
 	for _, arg := range queries {
 		allowedQueries := map[string]bool{
@@ -48,13 +51,14 @@ func (lr Loginradius) PutAuthVerifyEmailByOtp(body interface{}, queries ...inter
 
 // Pass data in struct lrbody.ChangePassword as body to help ensure parameters satisfy API requirements; alternatively,
 // []byte or map[string]string{} could also be passed as body
-func (lr Loginradius) PutAuthChangePassword(body interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PutAuthChangePassword(ctx context.Context, body interface{}) (*httprutils.Response, error) {
 
 	request, err := lr.Client.NewPutReqWithToken("/identity/v2/auth/password/change", body)
 
 	if err != nil {
 		return nil, err
 	}
+	request.WithContext(ctx)
 
 	response, err := lr.Client.HTTPRClient.Send(*request)
 	return response, err
@@ -88,11 +92,12 @@ func (lr Loginradius) PutAuthLinkSocialIdentities(token string, body interface{}
 
 // Pass data in struct lrbody.EmailStr as body to help ensure parameters satisfy API requirements; alternatively,
 // []byte or map[string]string{} could also be passed as body
-func (lr Loginradius) PutResendEmailVerification(body interface{}, queries ...interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PutResendEmailVerification(ctx context.Context, body interface{}, queries ...interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/register", body)
 	if err != nil {
 		return nil, err
 	}
+	request.WithContext(ctx)
 
 	for _, arg := range queries {
 		allowedQueries := map[string]bool{
@@ -146,12 +151,13 @@ func (lr Loginradius) PutAuthResetPasswordByResetToken(body interface{}) (*httpr
 
 // Pass data in struct lrbody.ResetPwOtp as body to help ensure parameters satisfy API requirements;alternatively,
 // []byte or map[string]string{} could also be passed as body
-func (lr Loginradius) PutAuthResetPasswordByOTP(body interface{}, queries ...interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PutAuthResetPasswordByOTP(ctx context.Context, body interface{}, queries ...interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPutReq("/identity/v2/auth/password/reset", body)
 
 	if err != nil {
 		return nil, err
 	}
+	request.WithContext(ctx)
 
 	for _, arg := range queries {
 		allowedQueries := map[string]bool{

--- a/api/mfa/post.go
+++ b/api/mfa/post.go
@@ -1,6 +1,8 @@
 package mfa
 
 import (
+	"context"
+
 	"github.com/LoginRadius/go-sdk/httprutils"
 	lrvalidate "github.com/LoginRadius/go-sdk/internal/validate"
 )
@@ -14,8 +16,12 @@ import (
 // Optional query parameters: loginurl, verificationurl, emailtemplate, smstemplate2fa
 
 // Required post parameters: email - string; password - string;
-func (lr Loginradius) PostMFAEmailLogin(body interface{}, queries ...interface{}) (*httprutils.Response, error) {
+func (lr Loginradius) PostMFAEmailLogin(ctx context.Context, body interface{}, queries ...interface{}) (*httprutils.Response, error) {
 	request, err := lr.Client.NewPostReq("/identity/v2/auth/login/2fa", body)
+	if err != nil {
+		return nil, err
+	}
+	request.WithContext(ctx)
 	for _, arg := range queries {
 		allowedQueries := map[string]bool{
 			"verificationurl": true, "loginurl": true, "emailtemplate": true, "smstemplate2fa": true,

--- a/demo/pkg/handleposts/login.go
+++ b/demo/pkg/handleposts/login.go
@@ -34,6 +34,7 @@ func Login(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	json.Unmarshal(b, &credentials)
 
 	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(
+		r.Context(),
 		credentials,
 	)
 	if err != nil {

--- a/demo/pkg/handleposts/mfa.go
+++ b/demo/pkg/handleposts/mfa.go
@@ -34,6 +34,7 @@ func MfaLogin(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	json.Unmarshal(b, &credentials)
 
 	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(
+		r.Context(),
 		credentials,
 	)
 	if err != nil {

--- a/demo/pkg/handleposts/password.go
+++ b/demo/pkg/handleposts/password.go
@@ -32,6 +32,7 @@ func ForgotPassword(w http.ResponseWriter, r *http.Request, ps httprouter.Params
 	b, _ := ioutil.ReadAll(r.Body)
 	json.Unmarshal(b, &email)
 	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(
+		r.Context(),
 		email,
 		map[string]string{"resetpasswordurl": r.URL.Query().Get("reset_password_url")},
 	)

--- a/demo/pkg/handleputs/password.go
+++ b/demo/pkg/handleputs/password.go
@@ -84,7 +84,7 @@ func ChangePassword(w http.ResponseWriter, r *http.Request, ps httprouter.Params
 	}
 
 	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).
-		PutAuthChangePassword(data)
+		PutAuthChangePassword(r.Context(), data)
 
 	if err != nil {
 		errors = errors + err.(lrerror.Error).OrigErr().Error()

--- a/httprutils/httprutils.go
+++ b/httprutils/httprutils.go
@@ -3,6 +3,7 @@ package httprutils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +31,18 @@ type Request struct {
 	Headers     map[string]string
 	QueryParams map[string]string
 	Body        *bytes.Buffer
+	// Ctx carries trace/cancellation context for the outbound HTTP request.
+	// When nil, BuildRequestObject falls back to context.Background() to
+	// preserve backward compatibility with callers that don't set it.
+	Ctx context.Context
+}
+
+// WithContext returns the request with ctx attached so the outbound HTTP
+// request inherits trace and cancellation propagation. Returns the receiver
+// for fluent chaining.
+func (r *Request) WithContext(ctx context.Context) *Request {
+	r.Ctx = ctx
+	return r
 }
 
 // DefaultClient is used if no custom HTTP client is defined
@@ -66,7 +79,11 @@ func BuildRequestObject(request Request) (*http.Request, error) {
 		request.Body = encodedBody
 	}
 
-	req, err := http.NewRequest(string(request.Method), request.URL, request.Body)
+	ctx := request.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, string(request.Method), request.URL, request.Body)
 	if err != nil {
 		err = lrerror.New("EncodingError", "Error constructing http request", err)
 		return req, err

--- a/lrtest/lrintegrationtest/authentication_test.go
+++ b/lrtest/lrintegrationtest/authentication_test.go
@@ -1,6 +1,7 @@
 package lrintegrationtest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -128,7 +129,7 @@ func TestPostAuthForgotPassword(t *testing.T) {
 	_, _, _, testEmail, _, lrclient, teardownTestCase := setupLogin(t)
 	defer teardownTestCase(t)
 	email := TestEmail{testEmail}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(email, map[string]string{"resetpasswordurl": "resetpassword.com"})
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(context.Background(), email, map[string]string{"resetpasswordurl": "resetpassword.com"})
 	if err != nil {
 		t.Errorf("Error making PostAuthForgotPassword call: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestPostAuthForgotPasswordInvalidQuery(t *testing.T) {
 	_, _, _, testEmail, _, lrclient, teardownTestCase := setupLogin(t)
 	defer teardownTestCase(t)
 	email := TestEmail{testEmail}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(email, map[string]string{"wrongqueryname": "www.example.com"})
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(context.Background(), email, map[string]string{"wrongqueryname": "www.example.com"})
 	if err.(lrerror.Error).Code() != "ValidationError" {
 		t.Errorf("PostAuthForgotPassword should fail with ValidationError but did not :%v, %+v", res.Body, err)
 	}
@@ -152,7 +153,7 @@ func TestPostAuthForgotPasswordInvalid(t *testing.T) {
 	_, _, _, _, _, lrclient, teardownTestCase := setupLogin(t)
 	defer teardownTestCase(t)
 	invalid := struct{ foo string }{"bar"}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(invalid, map[string]string{"resetpasswordurl": "www.example.com"})
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthForgotPassword(context.Background(), invalid, map[string]string{"resetpasswordurl": "www.example.com"})
 	if err.(lrerror.Error).Code() != "LoginradiusRespondedWithError" {
 		t.Errorf("PostAuthForgotPassword should fail with LoginradiusRespondedWithError but did not :%v, %+v", res.Body, err)
 	}
@@ -162,7 +163,7 @@ func TestPostAuthLoginByEmail(t *testing.T) {
 	_, _, _, testEmail, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	testLogin := TestEmailLogin{testEmail, testEmail}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(testLogin)
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(context.Background(), testLogin)
 	if err != nil {
 		t.Errorf("Error making PostAuthLoginByEmail call: %v", err)
 	}
@@ -171,7 +172,7 @@ func TestPostAuthLoginByEmail(t *testing.T) {
 		t.Errorf("Error returned from PostAuthLoginByEmail call: %v", err)
 	}
 
-	res, err = lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(testLogin, map[string]string{"emailtemplate": "hello"})
+	res, err = lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(context.Background(), testLogin, map[string]string{"emailtemplate": "hello"})
 
 	if err != nil {
 		t.Errorf("Error making PostAuthLoginByEmail call with optional queries: %v", err)
@@ -186,7 +187,7 @@ func TestPostAuthLoginByEmailInvalidBody(t *testing.T) {
 	_, _, _, _, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	invalid := struct{ foo string }{"bar"}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(invalid)
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(context.Background(), invalid)
 	if err.(lrerror.Error).Code() != "LoginradiusRespondedWithError" {
 		t.Errorf("PostAuthLoginByEmail should fail with LoginradiusRespondedWithError but did not: %v", res.Body)
 	}
@@ -196,7 +197,7 @@ func TestPostAuthLoginByEmailInvalidQuery(t *testing.T) {
 	_, _, _, email, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	user := TestEmailLogin{email, email}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(user, map[string]string{"invalidparam": "value"})
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PostAuthLoginByEmail(context.Background(), user, map[string]string{"invalidparam": "value"})
 	if err.(lrerror.Error).Code() != "ValidationError" {
 		t.Errorf("PostAuthLoginByEmail should fail with ValidationError but did not :%v, %+v", res.Body, err)
 	}
@@ -498,7 +499,7 @@ func TestPutAuthChangePassword(t *testing.T) {
 	_, _, _, email, _, lrclient, teardownTestCase := setupLogin(t)
 	defer teardownTestCase(t)
 	passwords := PassChange{email, email + "1"}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutAuthChangePassword(passwords)
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutAuthChangePassword(context.Background(), passwords)
 	if err != nil {
 		t.Errorf("Error calling PutAuthChangePassword: %+v", err)
 	}
@@ -512,7 +513,7 @@ func TestPutResendEmailVerification(t *testing.T) {
 	_, retEmail, _, lrclient, teardownTestCase := setupEmailVerificationAccount(t)
 	defer teardownTestCase(t)
 	emailRef := TestEmail{retEmail}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(emailRef)
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(context.Background(), emailRef)
 	if err != nil {
 		t.Errorf("Error calling PutResendEmailVerification: %v", err)
 	}
@@ -521,7 +522,7 @@ func TestPutResendEmailVerification(t *testing.T) {
 		t.Errorf("Error returned for PutResendEmailVerification: %v", err)
 	}
 
-	res, err = lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(emailRef, map[string]string{"emailtemplate": "hello"})
+	res, err = lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(context.Background(), emailRef, map[string]string{"emailtemplate": "hello"})
 	if err != nil {
 		t.Errorf("Error calling PutResendEmailVerification: %v", err)
 	}
@@ -535,7 +536,7 @@ func TestPutResendEmailVerificationInvalid(t *testing.T) {
 	_, retEmail, _, lrclient, teardownTestCase := setupEmailVerificationAccount(t)
 	defer teardownTestCase(t)
 	emailRef := TestEmail{retEmail}
-	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(map[string]string{"invalidquery": "hello"}, emailRef)
+	res, err := lrauthentication.Loginradius(lrauthentication.Loginradius{lrclient}).PutResendEmailVerification(context.Background(), map[string]string{"invalidquery": "hello"}, emailRef)
 	if err == nil || err.(lrerror.Error).Code() != "ValidationError" {
 		t.Errorf("Should fail with ValidationError, but got instead:%+v, %v", res, err)
 	}

--- a/lrtest/lrintegrationtest/multifactor_test.go
+++ b/lrtest/lrintegrationtest/multifactor_test.go
@@ -1,6 +1,7 @@
 package lrintegrationtest
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestPostMFAEmailLogin(t *testing.T) {
 	_, _, _, testEmail, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	testLogin := TestEmailLogin{testEmail, testEmail}
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(testLogin)
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(), testLogin)
 	if err != nil {
 		t.Errorf("Error making PostMFAEmailLogin call: %v", err)
 	}
@@ -28,7 +29,7 @@ func TestPostMFAEmailLogin(t *testing.T) {
 		t.Errorf("Error returned from PostMFAEmailLogin call: %v", err)
 	}
 
-	res, err = mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(testLogin, map[string]string{"emailtemplate": "hello"})
+	res, err = mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(), testLogin, map[string]string{"emailtemplate": "hello"})
 
 	if err != nil {
 		t.Errorf("Error making PostMFAEmailLogin call with optional queries: %v", err)
@@ -45,7 +46,7 @@ func TestPostMFAEmailLoginInvalidBody(t *testing.T) {
 	_, _, _, _, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	invalid := struct{ foo string }{"bar"}
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(invalid)
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(), invalid)
 	if err.(lrerror.Error).Code() != "LoginradiusRespondedWithError" {
 		t.Errorf("PostMFAEmailLogin should fail with LoginradiusRespondedWithError but did not: %v", res.Body)
 	}
@@ -57,7 +58,7 @@ func TestPostMFAEmailLoginInvalidQuery(t *testing.T) {
 	_, _, _, email, lrclient, teardownTestCase := setupAccount(t)
 	defer teardownTestCase(t)
 	user := TestEmailLogin{email, email}
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(user, map[string]string{"invalidparam": "value"})
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(), user, map[string]string{"invalidparam": "value"})
 	if err.(lrerror.Error).Code() != "ValidationError" {
 		t.Errorf("PostMFAEmailLogin should fail with ValidationError but did not :%v, %+v", res.Body, err)
 	}
@@ -210,7 +211,7 @@ func TestPutMFAValidateGoogleAuthCode(t *testing.T) {
 
 	lrclient, _ := lr.NewLoginradius(&cfg)
 
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(),
 		// Set user credentials here
 		map[string]string{"email": "", "password": ""},
 	)
@@ -256,7 +257,7 @@ func TestPutMFAValidateOTP(t *testing.T) {
 
 	lrclient, _ := lr.NewLoginradius(&cfg)
 
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(),
 		// Set user credentials here
 		map[string]string{"email": "blueberries@mailinator.com", "password": "password"},
 	)
@@ -298,7 +299,7 @@ func TestPutMFAUpdatePhoneNumber(t *testing.T) {
 	}
 
 	lrclient, _ := lr.NewLoginradius(&cfg)
-	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(
+	res, err := mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(),
 		// Set user credentials here
 		map[string]string{"email": "blueberries@mailinator.com", "password": "password"},
 	)
@@ -435,7 +436,7 @@ func TestPutMFAValidateBackupCode(t *testing.T) {
 	}
 
 	// Get secondfactorauthenticationtoken
-	res, err = mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(
+	res, err = mfa.Loginradius(mfa.Loginradius{lrclient}).PostMFAEmailLogin(context.Background(),
 		// Set user credentials here
 		map[string]string{"email": "blueberries@mailinator.com", "password": "password"},
 	)


### PR DESCRIPTION
Add a Ctx field to httprutils.Request and a WithContext helper, then have BuildRequestObject build the *http.Request with http.NewRequestWithContext (falling back to context.Background() when Ctx is nil — non-breaking for existing SDK methods that don't yet plumb ctx).

Update the seven SDK methods consumed by sun-ms-profile's UPSx auth flows to accept ctx and attach it via request.WithContext(ctx) so the outbound LoginRadius call inherits the caller's trace/cancellation context:

- PostAuthLoginByEmail
- PostAuthForgotPassword
- PutAuthVerifyEmailByOtp
- PutAuthChangePassword
- PutResendEmailVerification
- PutAuthResetPasswordByOTP
- PostMFAEmailLogin

Updated demo handlers and integration test callsites accordingly.